### PR TITLE
feat: adding GameItem-Entity

### DIFF
--- a/src/modules/marketplace/controllers/gameItem.controller.ts
+++ b/src/modules/marketplace/controllers/gameItem.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Post, Body, Param } from "@nestjs/common";
+import { GameItemService } from "../services/gameItem.service";
+import { GameItem } from "../entities/gameItem.entity";
+import { CreateGameItemDTO } from "../dtos/gameItem.dto";
+
+@Controller("game-items")
+export class GameItemController {
+  constructor(private readonly gameItemService: GameItemService) {}
+
+  @Get()
+  async getAllItems(): Promise<GameItem[]> {
+    return this.gameItemService.getAllItems();
+  }
+
+  @Get(":ownerId")
+  async getItemsByOwner(@Param("ownerId") ownerId: number): Promise<GameItem[]> {
+    return this.gameItemService.getItemsByOwner(ownerId);
+  }
+
+  @Post()
+  async createItem(@Body() itemData: CreateGameItemDTO): Promise<GameItem> { // <-- Cambiar el tipo aquí
+    return this.gameItemService.createItem(itemData);
+  }
+}

--- a/src/modules/marketplace/dtos/gameItem.dto.ts
+++ b/src/modules/marketplace/dtos/gameItem.dto.ts
@@ -1,0 +1,24 @@
+import { IsEnum, IsNotEmpty, IsBoolean, IsNumber, IsOptional, IsObject } from "class-validator";
+import { ItemType, Rarity } from "../entities/gameItem.entity";
+
+export class CreateGameItemDTO {
+  @IsNotEmpty()
+  @IsNumber()
+  ownerId: number;
+
+  @IsNotEmpty()
+  name: string;
+
+  @IsEnum(ItemType)
+  type: ItemType;
+
+  @IsEnum(Rarity)
+  rarity: Rarity;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+
+  @IsBoolean()
+  isNFT: boolean;
+}

--- a/src/modules/marketplace/entities/gameItem.entity.ts
+++ b/src/modules/marketplace/entities/gameItem.entity.ts
@@ -1,0 +1,49 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from "typeorm";
+
+export enum ItemType {
+  WEAPON = "WEAPON",
+  ARMOR = "ARMOR",
+  POTION = "POTION",
+  RESOURCE = "RESOURCE",
+  NFT = "NFT",
+}
+
+export enum Rarity {
+  COMMON = "COMMON",
+  RARE = "RARE",
+  EPIC = "EPIC",
+  LEGENDARY = "LEGENDARY",
+}
+
+@Entity("game_items")
+export class GameItem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  ownerId: number;
+
+  @Column()
+  name: string;
+
+  @Column({
+    type: "enum",
+    enum: ItemType,
+  })
+  type: ItemType;
+
+  @Column({
+    type: "enum",
+    enum: Rarity,
+  })
+  rarity: Rarity;
+
+  @Column("json", { nullable: true })
+  metadata: Record<string, any>;
+
+  @Column({ default: false })
+  isNFT: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/modules/marketplace/repositories/gameItem.repository.ts
+++ b/src/modules/marketplace/repositories/gameItem.repository.ts
@@ -1,0 +1,15 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { GameItem } from "../entities/gameItem.entity";
+
+@Injectable()
+export class GameItemRepository extends Repository<GameItem> {
+  constructor(@InjectRepository(GameItem) private readonly repository: Repository<GameItem>) {
+    super(repository.target, repository.manager, repository.queryRunner);
+  }
+
+  async findByOwner(ownerId: number): Promise<GameItem[]> {
+    return this.repository.find({ where: { ownerId } });
+  }
+}

--- a/src/modules/marketplace/services/gameItem.service.ts
+++ b/src/modules/marketplace/services/gameItem.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { GameItem } from "../entities/gameItem.entity";
+import { CreateGameItemDTO } from "../dtos/gameItem.dto";
+
+@Injectable()
+export class GameItemService {
+  constructor(
+    @InjectRepository(GameItem)
+    private readonly gameItemRepository: Repository<GameItem>
+  ) {}
+
+  async getAllItems(): Promise<GameItem[]> {
+    return this.gameItemRepository.find();
+  }
+
+  async getItemsByOwner(ownerId: number): Promise<GameItem[]> {
+    return this.gameItemRepository.find({ where: { ownerId } });
+  }
+
+  async createItem(itemData: CreateGameItemDTO): Promise<GameItem> {
+    const newItem = this.gameItemRepository.create(itemData);
+    return this.gameItemRepository.save(newItem);
+  }
+}


### PR DESCRIPTION
## 🚀 Feature: Implement Game Item Entity

**Closes #27**  

---

### 📌 Description
This PR introduces the **Game Item System**, allowing players to manage their in-game items efficiently. The system enables users to **store, retrieve, and manage** game items, including **NFTs and non-NFT assets**. Items can be categorized by **type and rarity**, with metadata for additional attributes.

---

## ✅ Changes Made

### 1️⃣ Created `GameItem` Entity
- Defines attributes:
  - `id`, `ownerId`, `name`, `type`, `rarity`, `metadata`, `isNFT`, `createdAt`.
- Uses enums for `type` (WEAPON, ARMOR, POTION, RESOURCE, NFT) and `rarity` (COMMON, RARE, EPIC, LEGENDARY).
- Supports additional metadata storage.

### 2️⃣ Implemented Game Item Repository
- Handles database interactions using **TypeORM**.
- Provides methods for retrieving game items by **owner**.

### 3️⃣ Developed Game Item Service
- Implements logic to:
  - **Retrieve all game items**.
  - **Get items by owner**.
  - **Create new game items** with validation.
  - **Store metadata dynamically**.

### 4️⃣ Created DTOs for Input Validation
- Ensures input integrity using **class-validator**.
- Enforces required properties such as `ownerId`, `name`, `type`, and `rarity`.

---

### 📌 Additional Notes
- This PR lays the foundation for managing **tradable** in-game items.
- Future improvements may include **item updates, deletions, and trading mechanisms**.

